### PR TITLE
Refresh README: accurate platforms, product overview, and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 We know how hard it is to be a developer. It doesn't have to be. <br/>
 daily.dev is the homepage every developer deserves. <br/>
-Personalized news feed, dev communities, and search, much better than what’s out there. Maybe ;)
+A personalized developer news feed, dev communities, and search. Free, and open source. Much better than what's out there. Maybe ;)
 
 [Product Docs][product-docs-link] · [Changelog][changelog-link] · [Report a Bug][report-bug-link] · [Request a Feature][github-discussions-link] · [Swag Store][swag-store-link] · [Brand Assets][brand-book-link]
 
 <!-- SHIELD GROUP -->
 
 [![][chrome-users-shield]][chrome-users-link]
-[![][extension-rating-shield]][extension-rating-link]
+[![][chrome-rating-shield]][chrome-users-link]
 [![][latest-version-shield]][latest-version-link]<br/>
 [![][github-stars-shield]][github-stars-link]
 [![][github-license-shield]][github-license-link]<br/>
@@ -33,9 +33,9 @@ Personalized news feed, dev communities, and search, much better than what’s o
 
 <sup>Want to contribute? [Run our app locally](https://github.com/dailydotdev/daily?tab=readme-ov-file#-running-dailydev-locally)</sup>
 
-<img src="assets/github repo banner with browser.png" alt="daily.dev cover image" width="100%">
+<img src="assets/github repo banner with browser.png" alt="daily.dev personalized developer news feed shown in a browser new tab" width="100%">
 </br>
-<a href="https://youtu.be/igZCEr3HwCg"><strong>👀 Watch it in action → </strong></a>
+<a href="https://youtu.be/igZCEr3HwCg"><strong>👀 Watch daily.dev in action → </strong></a>
 
 </div>
 
@@ -44,9 +44,21 @@ Personalized news feed, dev communities, and search, much better than what’s o
 > [!IMPORTANT]
 > Star us to show your support and love for daily.dev ⭐️
 
-daily.dev is a professional network for developers to learn, collaborate, and grow together. With daily.dev, you can discover a wide variety of professional knowledge, create groups where you can collaborate with other developers you appreciate, and discuss the latest trends in the developer ecosystem. It works offline and is available both as a browser extension and as a Progressive Web App (PWA). 
+daily.dev is a free, open source personalized news feed for developers, used by millions of developers worldwide. It aggregates articles, tutorials, release notes, and news from thousands of trusted sources across the web, and personalizes your feed based on the tags you follow (like #webdev, #ai, #devops) and what you read.
 
-<img src="assets/github repo star graphic.png" alt="daily.dev star banner" width="100%">
+You can use daily.dev as a new tab browser extension for Chrome and Edge, as a web app, or with the daily.dev mobile apps for iOS and Android. Beyond the feed, daily.dev is a community: join Squads to share and discuss content with other developers, comment on posts, bookmark what you want to read later, and search across everything.
+
+### ✨ What you get with daily.dev
+
+* 📰 **Personalized feed**: the best developer content from thousands of sources, tuned to your stack via tags and your reading activity
+* 🧩 **New tab extension**: turn every new browser tab into your developer homepage (Chrome and Edge)
+* 📱 **Mobile apps**: the same feed and community on iOS and Android
+* 👥 **Squads**: developer communities for sharing and discussing content with your team or people who share your interests
+* 💬 **Discussions**: comment on posts and learn from how other developers think
+* 🔖 **Bookmarks and reading list**: save posts to read later, wherever you are
+* 🔍 **Search**: find posts, tags, sources, and discussions across the entire network
+
+<img src="assets/github repo star graphic.png" alt="daily.dev GitHub stars growth banner" width="100%">
 
 <details>
   <summary><kbd>Star History</kbd></summary>
@@ -58,27 +70,33 @@ daily.dev is a professional network for developers to learn, collaborate, and gr
 
 ## 📌 Get daily.dev
 
-daily.dev is currently available for Google Chrome and Microsoft Edge. There's also a PWA for mobile devices. 
+daily.dev is available as a browser extension for Google Chrome and Microsoft Edge, as a web app, and as a mobile app for iOS and Android.
 
 Get it now on:
 
 <p align="center">
     <a href="https://r.daily.dev/chrome">
-    <img src="https://img.shields.io/badge/%20-Chrome-red?logo=google-chrome&logoColor=white" alt="Download for Chrome" />
+    <img src="https://img.shields.io/badge/%20-Chrome-red?logo=google-chrome&logoColor=white" alt="Download daily.dev for Chrome" />
     </a>
     <a href="https://microsoftedge.microsoft.com/addons/detail/dailydev-news-for-busy/cbdhgldgiancdheindpekpcbkccpjaeb">
-    <img src="https://img.shields.io/badge/%20-Edge-blue?logo=microsoft-edge&logoColor=white" alt="Download for Edge" />
+    <img src="https://img.shields.io/badge/%20-Edge-blue?logo=microsoft-edge&logoColor=white" alt="Download daily.dev for Edge" />
     </a>
-    <a href="https://api.daily.dev/get">
-    <img src="https://img.shields.io/badge/%20-Mobile-502ab0" alt="Download for Mobile" />
+    <a href="https://apps.apple.com/app/daily-dev/id6740634400">
+    <img src="https://img.shields.io/badge/%20-iOS-black?logo=apple&logoColor=white" alt="Download daily.dev for iOS" />
+    </a>
+    <a href="https://play.google.com/store/apps/details?id=dev.daily">
+    <img src="https://img.shields.io/badge/%20-Android-3DDC84?logo=android&logoColor=white" alt="Download daily.dev for Android" />
+    </a>
+    <a href="https://app.daily.dev">
+    <img src="https://img.shields.io/badge/%20-Web%20App-502ab0" alt="Open the daily.dev web app" />
     </a>
 </p>
 
 ## 📯 Philosophy
 
-We recognize that developers today have the greatest power as a professional group to drive change and affect the lives of billions. Many platforms provide developers with tools that serve their success or the goals of their workplace, but daily.dev is by design for developers themselves. 
+We recognize that developers today have the greatest power as a professional group to drive change and affect the lives of billions. Many platforms provide developers with tools that serve their success or the goals of their workplace, but daily.dev is by design for developers themselves.
 
-We, as developers, know how challenging it is to grow professionally with so much going on, and that's why we built daily.dev — to make it easy for us to navigate the abundant content and discover all the knowledge they need with zero effort.
+We, as developers, know how challenging it is to grow professionally with so much going on, and that's why we built daily.dev: to make it easy for us to navigate the abundant content out there and discover all the knowledge we need with zero effort.
 
 You can use daily.dev to:
 
@@ -90,6 +108,44 @@ You can use daily.dev to:
 * 🚀 Collaborate with other developers you know and appreciate
 
 
+## ❓ FAQ
+
+<details>
+<summary><strong>Is daily.dev free?</strong></summary>
+<br>
+Yes. The core daily.dev experience (the personalized feed, extension, mobile apps, Squads, bookmarks, and search) is free. There is an optional paid subscription, daily.dev Plus, that adds power features on top.
+</details>
+
+<details>
+<summary><strong>Is daily.dev open source?</strong></summary>
+<br>
+Yes. daily.dev is open source under the AGPL-3.0 license. This repository is the central hub, and the frontend applications (extension and web app) live in <a href="https://github.com/dailydotdev/apps">dailydotdev/apps</a>.
+</details>
+
+<details>
+<summary><strong>Which platforms does daily.dev support?</strong></summary>
+<br>
+Browser extension for Google Chrome and Microsoft Edge, a web app at <a href="https://app.daily.dev">app.daily.dev</a>, and native mobile apps for <a href="https://apps.apple.com/app/daily-dev/id6740634400">iOS</a> and <a href="https://play.google.com/store/apps/details?id=dev.daily">Android</a>.
+</details>
+
+<details>
+<summary><strong>How does the feed personalization work?</strong></summary>
+<br>
+You pick the tags and sources you care about (for example #react, #kubernetes, #ai), and the feed learns from what you read, upvote, and bookmark. You stay in control: you can follow or block tags and sources at any time, and switch between personalized and popular feeds.
+</details>
+
+<details>
+<summary><strong>How is daily.dev different from dev.to or Hacker News?</strong></summary>
+<br>
+They solve different problems. dev.to is a blogging community where most content is written on the platform itself. Hacker News is a single shared ranked list of tech and startup links, the same for everyone. daily.dev aggregates developer content from thousands of sources across the web and personalizes the feed to your stack, with communities (Squads) built around it. Many developers use daily.dev alongside these platforms.
+</details>
+
+<details>
+<summary><strong>How do I report a bug or request a feature?</strong></summary>
+<br>
+Open a <a href="https://github.com/dailydotdev/daily/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=---bug-report.yml&title=%F0%9F%90%9B+BUG%3A+">bug report</a> or start a <a href="https://github.com/dailydotdev/daily/discussions/new?category=feature-requests">feature request discussion</a> right here in this repository.
+</details>
+
 ## 🌲 daily.dev projects
 
 daily.dev might look simple on the surface, but actually, it is powered by a complex and robust system of different applications. It contains several services, some are big, others are micro and easy to maintain. Below is the list of different projects that we maintain under daily.dev.
@@ -100,6 +156,8 @@ daily.dev might look simple on the surface, but actually, it is powered by a com
 *  [daily](https://github.com/dailydotdev/daily) - This is the repository you are currently at. It serves as a central place for all the projects. It contains documentation, community ideas, suggestions, and whatnot.
 
 *  [docs](https://github.com/dailydotdev/docs) - This is the repository for official product documentation of daily.dev.
+
+*  [awesome-developer-essentials](https://github.com/dailydotdev/awesome-developer-essentials) - A community-curated list of essential resources for developers, maintained by the daily.dev team.
 
 
 ### 🎨 Frontend
@@ -148,10 +206,10 @@ You are more than welcome. Before contributing, kindly check our [guidelines](ht
 ## 💬 What do you think of daily.dev?
 
 <div align="left">
-    <p><a href="https://twitter.com/dailydotdev/"><img alt="Twitter @dailydotdev" align="center" src="https://img.shields.io/badge/twitter-%231DA1F2.svg?&style=for-the-badge&logo=twitter&logoColor=white" /></a>&nbsp; Tweet us @dailydotdev to share your thoughts and stay up-to-date. </p>
+    <p><a href="https://twitter.com/dailydotdev/"><img alt="daily.dev on X" align="center" src="https://img.shields.io/badge/X-%23000000.svg?&style=for-the-badge&logo=x&logoColor=white" /></a>&nbsp; Follow @dailydotdev to share your thoughts and stay up-to-date. </p>
     <p><a href="https://www.producthunt.com/products/daily-dev"><img alt="daily.dev at ProductHunt" align="center" src="https://img.shields.io/badge/producthunt-%23DA552F.svg?&style=for-the-badge&logo=product-hunt&logoColor=white" /></a>&nbsp; Check out our Product Hunt page.</p>
     <p><a href="https://daily.dev"><img alt="daily.dev Website" align="center" src="https://img.shields.io/badge/Daily Website-%233693F3.svg?&style=for-the-badge&logo=icloud&logoColor=white" /></a>&nbsp; Visit our home for a bunch of useful links.</p>
-    <p><a href="https://chromewebstore.google.com/detail/daily-20-source-for-busy/jlmpjdjjbgclbocgajdjefcidcncaied"><img alt="daily.dev at ChomeStore" align="center" src="https://img.shields.io/badge/Chrome Web Store-%234285F4.svg?&style=for-the-badge&logo=google-chrome&logoColor=white" /></a>&nbsp; See our Chrome Store page to grab the extension or share your feedback.</p>
+    <p><a href="https://chromewebstore.google.com/detail/dailydev-the-homepage-dev/jlmpjdjjbgclbocgajdjefcidcncaied"><img alt="daily.dev at ChomeStore" align="center" src="https://img.shields.io/badge/Chrome Web Store-%234285F4.svg?&style=for-the-badge&logo=google-chrome&logoColor=white" /></a>&nbsp; See our Chrome Store page to grab the extension or share your feedback.</p>
     <p><a href="https://microsoftedge.microsoft.com/addons/detail/dailydev-news-for-busy/cbdhgldgiancdheindpekpcbkccpjaeb"><img alt="daily.dev at EdgeAddons" align="center" src="https://img.shields.io/badge/Edge Addons-%230078D7.svg?&style=for-the-badge&logo=microsoft-edge&logoColor=white" /></a>&nbsp; Check us out on Microsoft Edge Addons and let us know your thoughts.</p>
 
 ## 📑 License
@@ -177,14 +235,13 @@ Licensed under [AGPL-3.0](https://github.com/dailydotdev/daily/blob/master/LICEN
 
 [chrome-users-shield]: https://img.shields.io/chrome-web-store/users/jlmpjdjjbgclbocgajdjefcidcncaied?style=flat-square&logo=googlechrome&logoColor=white&label=chrome%20active%20users&labelColor=black&color=9E15D9
 [chrome-users-link]: https://chromewebstore.google.com/detail/dailydev-the-homepage-dev/jlmpjdjjbgclbocgajdjefcidcncaied
-[extension-rating-shield]: https://img.shields.io/amo/rating/daily?style=flat-square&labelColor=black&color=0FC54F
-[extension-rating-link]: https://api.daily.dev/get
+[chrome-rating-shield]: https://img.shields.io/chrome-web-store/rating/jlmpjdjjbgclbocgajdjefcidcncaied?style=flat-square&label=chrome%20rating&labelColor=black&color=0FC54F
 [latest-version-shield]: https://img.shields.io/chrome-web-store/v/jlmpjdjjbgclbocgajdjefcidcncaied?style=flat-square&label=latest%20version&labelColor=black&color=0FC54F
 [latest-version-link]: https://api.daily.dev/get
 [github-stars-shield]: https://img.shields.io/github/stars/dailydotdev/daily?style=flat-square&logo=github&labelColor=black&color=508CF9
 [github-stars-link]: https://github.com/dailydotdev/daily/stargazers
 [github-license-shield]: https://img.shields.io/github/license/dailydotdev/daily?style=flat-square&logo=github&labelColor=black&color=508CF9
-[github-license-link]: https://github.com/dailydotdev/daily/issues
+[github-license-link]: https://github.com/dailydotdev/daily/blob/master/LICENSE
 
 <!-- SHARE BUTTONS GROUP -->
 


### PR DESCRIPTION
## What changed

- **About section**: added a clear description of what daily.dev is (personalized feed, sources, tags) and a feature list (feed, new tab extension, mobile apps, Squads, discussions, bookmarks, search).
- **Platform availability**: the README said Chrome, Edge, and a mobile PWA. Updated to the current reality: Chrome and Edge extensions, the web app, and the native iOS and Android apps, with direct App Store and Google Play links.
- **Fixed a broken badge**: the Mozilla add-on rating badge renders "invalid" because there is no official daily.dev add-on listed on AMO. Replaced it with the Chrome Web Store rating badge.
- **New FAQ section**: answers the questions people ask most about the project: is it free, is it open source, which platforms, how personalization works, and how it compares to adjacent platforms.
- **Small fixes**: license badge now links to the LICENSE file (was pointing at issues), updated the outdated Chrome Web Store listing URL in the footer, Twitter badge updated to X, added awesome-developer-essentials to the projects list, and improved image alt text.

## Why

The README is the front door of the project and one of the most-visited daily.dev pages on the web. It was out of date on platform availability (no mention of the native mobile apps) and didn't answer the basic questions visitors arrive with.