### PR TITLE
feat: statusline feedback fixes + setup skill (plugin v0.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official daily.dev plugins for Claude Code",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {
       "name": "daily.dev",
       "source": "./.claude-plugin/plugins/daily.dev",
       "description": "Overcome LLM knowledge cutoffs with real-time developer content. daily.dev aggregates articles from thousands of sources, validated by community engagement, with structured taxonomy for precise discovery.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "author": {
         "name": "daily.dev"
       },

--- a/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "daily.dev",
   "description": "Access personalized developer content feeds from daily.dev - the professional network for developers. Surface relevant articles, tutorials, and discussions based on user interests.",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/.claude-plugin/plugins/daily.dev/README.md
+++ b/.claude-plugin/plugins/daily.dev/README.md
@@ -4,11 +4,31 @@ Real-time developer content from daily.dev, inside Claude Code:
 
 - **daily.dev skill** — query feeds, search posts, and pull personalized content via the daily.dev API (requires a Plus API token; see the skill for setup).
 - **`/daily.dev:trends` skill** — today's curated headlines and most-upvoted posts, no token needed.
-- **Statusline** — rotating daily.dev headlines at the bottom of Claude Code while you wait. Curated major headlines interleaved with the community's most-upvoted posts of the day, refreshed every 10 minutes, rotating every ~20 seconds. Headlines are clickable in terminals with hyperlink support (iTerm2, Kitty, WezTerm, Ghostty).
+- **Statusline** — rotating daily.dev headlines at the bottom of Claude Code while you wait. Curated major headlines interleaved with the community's most-upvoted posts of the day, refreshed every 10 minutes, rotating every ~60 seconds. Headlines are clickable in terminals with hyperlink support (iTerm2, Kitty, WezTerm, Ghostty).
+
+## Statusline setup
+
+Claude Code doesn't activate statuslines from plugins automatically — after installing the plugin, run:
+
+```
+/daily.dev:statusline
+```
+
+and Claude wires it into your `~/.claude/settings.json` (and can remove it again later). If you prefer to do it by hand, point `statusLine` at the plugin's script — the glob keeps it working across plugin updates:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node \"$(ls -td \"$HOME/.claude/plugins/cache/daily-dev/daily-dev\"/*/ | head -1)statusline/statusline.mjs\"",
+    "refreshInterval": 10
+  }
+}
+```
 
 ## Statusline notes
 
-- Enabling this plugin sets Claude Code's `statusLine` — if you already have a custom statusline, the plugin's takes over. Remove the `statusLine` block from the plugin's `settings.json` (or disable the plugin) to keep your own.
+- If you already have a custom statusline, setting this one replaces it — your Claude Code user settings hold a single `statusLine`.
 - Requires `node` on your PATH. Honors `NO_COLOR`.
 - Content is fetched anonymously from the public daily.dev API and cached in `~/.cache/dailydev-claude/`.
 

--- a/.claude-plugin/plugins/daily.dev/settings.json
+++ b/.claude-plugin/plugins/daily.dev/settings.json
@@ -1,7 +1,0 @@
-{
-  "statusLine": {
-    "type": "command",
-    "command": "node ${CLAUDE_PLUGIN_ROOT}/statusline/statusline.mjs",
-    "refreshInterval": 10
-  }
-}

--- a/.claude-plugin/plugins/daily.dev/skills/statusline/SKILL.md
+++ b/.claude-plugin/plugins/daily.dev/skills/statusline/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: statusline
+description: Set up (or remove) the daily.dev headlines statusline in Claude Code. Use when the user wants daily.dev headlines in their statusline, asks to enable/disable the daily.dev statusline, or the statusline is not showing after installing the plugin.
+---
+
+Wire the daily.dev headlines statusline into the user's Claude Code settings. Claude Code does not activate a statusline from plugin settings automatically, so this skill writes the `statusLine` config for the user.
+
+This plugin's statusline script lives at `${CLAUDE_PLUGIN_ROOT}/statusline/statusline.mjs`. That path is version-pinned (it changes on every plugin update), so DO NOT write it into settings literally. Instead, derive the version-independent parent directory (strip the trailing `/<version>` segment from `${CLAUDE_PLUGIN_ROOT}`) and use a shell glob that always resolves the most recently installed version.
+
+## Enable
+
+1. Read `~/.claude/settings.json` (create it as `{}` if missing).
+2. If a `statusLine` key already exists and is not the daily.dev one, show it to the user and ask before replacing it.
+3. Set the `statusLine` key, substituting `<PLUGIN_PARENT_DIR>` with the version-stripped parent of `${CLAUDE_PLUGIN_ROOT}`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node \"$(ls -td \"<PLUGIN_PARENT_DIR>\"/*/ | head -1)statusline/statusline.mjs\"",
+    "refreshInterval": 10
+  }
+}
+```
+
+4. Verify it renders by piping an empty JSON object to the resolved command, e.g. `echo '{}' | node "$(ls -td "<PLUGIN_PARENT_DIR>"/*/ | head -1)statusline/statusline.mjs"`. It should print a line starting with `daily.dev`.
+5. Tell the user to restart Claude Code (or start a new session) to see it, and mention headlines rotate about once a minute and are clickable in terminals with hyperlink support.
+
+## Disable
+
+Remove the `statusLine` key from `~/.claude/settings.json` if its command references this plugin's statusline script. If it points somewhere else, leave it alone and tell the user.
+
+## Notes
+
+- Requires `node` on PATH.
+- Anonymous impression telemetry can be disabled with `DAILY_DEV_TELEMETRY=0` in the environment; mention this if the user asks about privacy (full details in the plugin README).

--- a/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
+++ b/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
@@ -5,8 +5,9 @@
  * Rotating daily.dev headlines while you wait: curated major headlines
  * interleaved with the community's most-upvoted posts of the day.
  *
- * Enabled via this plugin's settings.json:
- *   { "statusLine": { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/statusline/statusline.mjs", "refreshInterval": 10 } }
+ * Claude Code does not activate statuslines from plugin settings — users wire
+ * this script into their own settings via the /daily.dev:statusline skill
+ * (or manually; see the plugin README).
  *
  * Design constraints:
  * - The statusline command must exit fast: all network I/O happens in a
@@ -36,7 +37,7 @@ const IDENTITY_FILE = join(CACHE_DIR, 'identity.json');
 const STATE_FILE = join(CACHE_DIR, 'impressions-state.json');
 const QUEUE_FILE = join(CACHE_DIR, 'events-queue.jsonl');
 const CACHE_TTL_MS = 10 * 60 * 1000; // refresh headlines every 10 min
-const ROTATE_SECONDS = 20; // show each headline for ~20s
+const ROTATE_SECONDS = 60; // show each headline for ~60s
 const IMPRESSION_DEDUP_MS = 30 * 60 * 1000; // log each post at most every 30 min
 const ORIGIN = 'https://api.daily.dev';
 const API = `${ORIGIN}/graphql`;
@@ -242,7 +243,6 @@ const style = (code) => (s) => (COLOR_ENABLED ? `\x1b[${code}m${s}\x1b[0m` : s);
 const dim = style('2');
 const bold = style('1');
 const purple = style('38;5;135'); // daily.dev accent
-const cyan = style('36');
 // OSC 8 hyperlink — clickable in iTerm2/Kitty/WezTerm/Ghostty; harmless elsewhere.
 // Links hit the click-tracking redirect, which lands on the post page with UTM.
 const link = (url, s) => `\x1b]8;;${url}\x1b\\${s}\x1b]8;;\x1b\\`;
@@ -264,14 +264,12 @@ function render(sessionInfo) {
   const idx = Math.floor(Date.now() / 1000 / ROTATE_SECONDS) % items.length;
   const item = items[idx];
   maybeLogImpression(item, cache);
-  const tag = item.kind === 'headline' ? purple('headlines') : cyan('popular');
   const stats = item.numUpvotes > 0 ? dim(` ▲${item.numUpvotes}`) : '';
-  const counter = dim(` [${idx + 1}/${items.length}]`);
   const title = link(
     `${ORIGIN}/c/${item.postId}?${UTM}`,
     bold(truncate(item.title, 90)),
   );
-  return `${prefix}${purple('daily.dev')} ${tag} ${title}${stats}${counter}`;
+  return `${prefix}${purple('daily.dev')} ${title}${stats}`;
 }
 
 // --- main ---


### PR DESCRIPTION
## Feedback fixes (statusline)

Addresses user feedback on the v0.4.0 statusline (#2130):

1. **Removed the `headlines`/`popular` tag** from the rendered line (the kind is still recorded in impression telemetry via `extra.feed`, so analytics keep the distinction).
2. **Removed the `[n/m]` rotation counter.**
3. **Slower rotation** — `ROTATE_SECONDS` 20 → 60, so each headline shows for about a minute.

Line now renders as: `<model> · daily.dev <clickable headline> ▲<upvotes>`

## Activation fix (the bigger one)

While testing, we found that **Claude Code ignores `statusLine` in plugin settings.json** — plugin settings only honor the `agent` and `subagentStatusLine` keys ([plugin docs](https://code.claude.com/docs/en/plugins-reference.md)). That means v0.4.0's statusline silently never activated for anyone who installed the plugin; anyone seeing it had wired it manually. Also confirmed: plugin `bin/` is only on the Bash tool's PATH (not the statusline process), and `${CLAUDE_PLUGIN_ROOT}` is not expanded in statusline commands — so there's no way for a plugin to ship a self-activating statusline today.

This PR:
- **Adds a `/daily.dev:statusline` setup skill** that writes the `statusLine` block into the user's `~/.claude/settings.json`, using a shell-glob path that resolves the latest installed plugin version so it survives plugin updates (skills *do* get `${CLAUDE_PLUGIN_ROOT}` expansion, which the skill uses to derive the path). It asks before replacing an existing custom statusline, and can also remove the config again.
- **Removes the inert plugin `settings.json`** and corrects the README claim that enabling the plugin sets the statusline; the README now documents the skill plus a copy-pasteable manual config.

## Testing

- Rendered the statusline locally via `echo '{}' | node statusline.mjs` — new minimal format confirmed, no tag/counter.
- Installed the plugin from a local directory marketplace and verified the version-glob command resolves and renders on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)