### PR TITLE
feat: fresh statusline rotation via seen-history + anonymousFeed (plugin v0.4.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official daily.dev plugins for Claude Code",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {
       "name": "daily.dev",
       "source": "./.claude-plugin/plugins/daily.dev",
       "description": "Overcome LLM knowledge cutoffs with real-time developer content. daily.dev aggregates articles from thousands of sources, validated by community engagement, with structured taxonomy for precise discovery.",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "author": {
         "name": "daily.dev"
       },

--- a/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "daily.dev",
   "description": "Access personalized developer content feeds from daily.dev - the professional network for developers. Surface relevant articles, tutorials, and discussions based on user interests.",
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
+++ b/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
@@ -36,8 +36,10 @@ const CACHE_FILE = join(CACHE_DIR, 'headlines.json');
 const IDENTITY_FILE = join(CACHE_DIR, 'identity.json');
 const STATE_FILE = join(CACHE_DIR, 'impressions-state.json');
 const QUEUE_FILE = join(CACHE_DIR, 'events-queue.jsonl');
-const CACHE_TTL_MS = 10 * 60 * 1000; // refresh headlines every 10 min
 const ROTATE_SECONDS = 60; // show each headline for ~60s
+// One full rotation of a ~20-item batch takes ~20 min; refresh in step with it
+// so every batch gets shown once before the next page replaces it.
+const CACHE_TTL_MS = 20 * 60 * 1000;
 const IMPRESSION_DEDUP_MS = 30 * 60 * 1000; // log each post at most every 30 min
 const ORIGIN = 'https://api.daily.dev';
 const API = `${ORIGIN}/graphql`;
@@ -61,22 +63,27 @@ function pluginVersion() {
 const APP_VERSION = pluginVersion();
 
 // Both queries are public (no auth): curated headlines + most-upvoted posts.
-const QUERY = `query ClaudeCodeStatusline {
-  headlines: majorHeadlines(first: 10) {
+const QUERY = `query ClaudeCodeStatusline($headlinesAfter: String, $popularAfter: String) {
+  headlines: majorHeadlines(first: 10, after: $headlinesAfter) {
+    pageInfo { endCursor hasNextPage }
     edges { node { id headline channel post { id numUpvotes numComments } } }
   }
-  popular: mostUpvotedFeed(first: 10, period: 1) {
+  popular: mostUpvotedFeed(first: 10, period: 1, after: $popularAfter) {
+    pageInfo { endCursor hasNextPage }
     edges { node { id title numUpvotes numComments tags } }
   }
 }`;
 
-async function refreshCache() {
+async function fetchPage(variables) {
   const res = await fetch(API, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ query: QUERY }),
+    body: JSON.stringify({ query: QUERY, variables }),
   });
-  const { data } = await res.json();
+  return (await res.json())?.data;
+}
+
+function interleave(data) {
   const seen = new Set();
   const items = [];
   // Interleave curated headlines and popular posts so rotation alternates flavors
@@ -103,6 +110,31 @@ async function refreshCache() {
       }
     }
   }
+  return items;
+}
+
+async function refreshCache() {
+  // Walk the feeds page by page across refreshes so each batch is new
+  // articles, not the same top-10 again; an exhausted feed (or a cursor the
+  // API no longer recognizes) restarts from the top, where fresh content has
+  // accumulated in the meantime.
+  const prev = readCache();
+  const cursors = prev?.cursors ?? {};
+  let data = await fetchPage({
+    headlinesAfter: cursors.headlines ?? null,
+    popularAfter: cursors.popular ?? null,
+  });
+  let items = interleave(data);
+  if (!items.length && (cursors.headlines || cursors.popular)) {
+    data = await fetchPage({ headlinesAfter: null, popularAfter: null });
+    items = interleave(data);
+  }
+  if (!items.length && prev?.items?.length) {
+    // fetch came back empty — keep showing the previous batch
+    items = prev.items;
+  }
+  const nextCursor = (conn) =>
+    conn?.pageInfo?.hasNextPage ? (conn.pageInfo.endCursor ?? null) : null;
   mkdirSync(CACHE_DIR, { recursive: true });
   // A fresh visit per refresh cycle; the collector dedupes on event_id + visit_id.
   writeFileSync(
@@ -111,6 +143,10 @@ async function refreshCache() {
       fetchedAt: Date.now(),
       visitId: randomUUID(),
       sessionId: randomUUID(),
+      cursors: {
+        headlines: nextCursor(data?.headlines),
+        popular: nextCursor(data?.popular),
+      },
       items,
     }),
   );

--- a/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
+++ b/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
@@ -38,8 +38,12 @@ const STATE_FILE = join(CACHE_DIR, 'impressions-state.json');
 const QUEUE_FILE = join(CACHE_DIR, 'events-queue.jsonl');
 const ROTATE_SECONDS = 60; // show each headline for ~60s
 // One full rotation of a ~20-item batch takes ~20 min; refresh in step with it
-// so every batch gets shown once before the next page replaces it.
+// so every batch gets shown once before the next one replaces it.
 const CACHE_TTL_MS = 20 * 60 * 1000;
+const HISTORY_FILE = join(CACHE_DIR, 'shown-history.json');
+const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000; // don't repeat a post within a day
+const MAX_ITEMS = 20; // batch size per refresh cycle
+const MIN_ITEMS = 10; // below this, recycle least-recently-shown items
 const IMPRESSION_DEDUP_MS = 30 * 60 * 1000; // log each post at most every 30 min
 const ORIGIN = 'https://api.daily.dev';
 const API = `${ORIGIN}/graphql`;
@@ -62,26 +66,17 @@ function pluginVersion() {
 }
 const APP_VERSION = pluginVersion();
 
-// Both queries are public (no auth): curated headlines + most-upvoted posts.
-const QUERY = `query ClaudeCodeStatusline($headlinesAfter: String, $popularAfter: String) {
-  headlines: majorHeadlines(first: 10, after: $headlinesAfter) {
-    pageInfo { endCursor hasNextPage }
+// Both queries are public (no auth): curated headlines + the ranked feed the
+// logged-out webapp homepage shows (version/supportedTypes match the webapp —
+// without them the resolver falls back to a stale generic feed).
+const QUERY = `query ClaudeCodeStatusline {
+  headlines: majorHeadlines(first: 10) {
     edges { node { id headline channel post { id numUpvotes numComments } } }
   }
-  popular: mostUpvotedFeed(first: 10, period: 1, after: $popularAfter) {
-    pageInfo { endCursor hasNextPage }
+  popular: anonymousFeed(first: 40, ranking: POPULARITY, version: 15, supportedTypes: ["article", "collection", "video:youtube"]) {
     edges { node { id title numUpvotes numComments tags } }
   }
 }`;
-
-async function fetchPage(variables) {
-  const res = await fetch(API, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ query: QUERY, variables }),
-  });
-  return (await res.json())?.data;
-}
 
 function interleave(data) {
   const seen = new Set();
@@ -114,39 +109,54 @@ function interleave(data) {
 }
 
 async function refreshCache() {
-  // Walk the feeds page by page across refreshes so each batch is new
-  // articles, not the same top-10 again; an exhausted feed (or a cursor the
-  // API no longer recognizes) restarts from the top, where fresh content has
-  // accumulated in the meantime.
+  // Freshness without deep pagination: always fetch the top of both feeds
+  // (curated headline inventory is small; the popular feed re-ranks all day
+  // as new posts land), then skip whatever already rotated through the line
+  // in the last 24h. If the unseen pool runs low, recycle the items shown
+  // longest ago instead of paginating into low-quality depths or going blank.
   const prev = readCache();
-  const cursors = prev?.cursors ?? {};
-  let data = await fetchPage({
-    headlinesAfter: cursors.headlines ?? null,
-    popularAfter: cursors.popular ?? null,
+  const now = Date.now();
+  let history = {};
+  try {
+    history = JSON.parse(readFileSync(HISTORY_FILE, 'utf8'));
+  } catch {
+    // first run
+  }
+  for (const item of prev?.items ?? []) {
+    history[item.postId] = prev.fetchedAt ?? now;
+  }
+  for (const [id, ts] of Object.entries(history)) {
+    if (now - ts > HISTORY_RETENTION_MS) delete history[id];
+  }
+
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: QUERY }),
   });
-  let items = interleave(data);
-  if (!items.length && (cursors.headlines || cursors.popular)) {
-    data = await fetchPage({ headlinesAfter: null, popularAfter: null });
-    items = interleave(data);
+  const { data } = await res.json();
+  const all = interleave(data);
+  let items = all.filter((i) => !history[i.postId]).slice(0, MAX_ITEMS);
+  if (items.length < MIN_ITEMS) {
+    const recycled = all
+      .filter((i) => history[i.postId])
+      .sort((a, b) => history[a.postId] - history[b.postId]);
+    items = items.concat(recycled.slice(0, MIN_ITEMS - items.length));
   }
   if (!items.length && prev?.items?.length) {
     // fetch came back empty — keep showing the previous batch
     items = prev.items;
   }
-  const nextCursor = (conn) =>
-    conn?.pageInfo?.hasNextPage ? (conn.pageInfo.endCursor ?? null) : null;
+
   mkdirSync(CACHE_DIR, { recursive: true });
+  writeFileSync(HISTORY_FILE, JSON.stringify(history));
   // A fresh visit per refresh cycle; the collector dedupes on event_id + visit_id.
   writeFileSync(
     CACHE_FILE,
     JSON.stringify({
-      fetchedAt: Date.now(),
+      fetchedAt: now,
       visitId: randomUUID(),
       sessionId: randomUUID(),
-      cursors: {
-        headlines: nextCursor(data?.headlines),
-        popular: nextCursor(data?.popular),
-      },
       items,
     }),
   );


### PR DESCRIPTION
## Problem

The statusline cache refetched the same top-10 headlines and popular posts every TTL, so the rotation cycled over the same ~20 articles all day.

## Fix

- **Community slot switched to `anonymousFeed`** (the logged-out homepage feed, with the webapp's `version`/`supportedTypes` args) instead of `mostUpvotedFeed` — continuously re-ranked, so it stays dynamic through the day.
- **No deep pagination** (per @idoshamun's review): every refresh fetches the top of both feeds and filters out posts already shown in the last 24h via a local `shown-history.json`. When the unseen pool drops below 10, it recycles the least-recently-shown items so the line never goes blank.
- Cache TTL 10 → 20 min to match one full rotation (20 items × 60s).

Verified live against prod: consecutive refreshes with zero overlap; forced full starvation returns recycled items oldest-shown-first.

*(Note: this description was briefly overwritten post-merge with the follow-up's text by mistake — restored. The server-driven-lines follow-up is its own PR.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)