### PR TITLE
feat: tag statusline /c/ links with the plugin's anonymous id (plugin v0.4.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official daily.dev plugins for Claude Code",
-    "version": "0.4.3"
+    "version": "0.4.4"
   },
   "plugins": [
     {
       "name": "daily.dev",
       "source": "./.claude-plugin/plugins/daily.dev",
       "description": "Overcome LLM knowledge cutoffs with real-time developer content. daily.dev aggregates articles from thousands of sources, validated by community engagement, with structured taxonomy for precise discovery.",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "author": {
         "name": "daily.dev"
       },

--- a/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/daily.dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "daily.dev",
   "description": "Access personalized developer content feeds from daily.dev - the professional network for developers. Surface relevant articles, tutorials, and discussions based on user interests.",
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
+++ b/.claude-plugin/plugins/daily.dev/statusline/statusline.mjs
@@ -72,6 +72,36 @@ const QUERY = `query ClaudeCodeStatusline($first: Int) {
   statuslineHeadlines(first: $first)
 }`;
 
+// Clicks reach /c/ with the browser's anonymous id, not this plugin's /boot
+// identity, so impressions and clicks can't be joined as-is. Tag each /c/
+// link with our id as cc_uid: the redirect logs the full query string into
+// the click event's query_params but forwards only utm_* to the post page,
+// so the id never leaks into webapp URLs. (cc_uid, not userid — that param
+// is reserved for referral traffic.)
+function tagClickUrls(line) {
+  if (!TELEMETRY_ENABLED) return line;
+  let userId;
+  try {
+    userId = JSON.parse(readFileSync(IDENTITY_FILE, 'utf8')).userId;
+  } catch {
+    return line; // no identity yet (first run offline)
+  }
+  if (!userId) return line;
+  return line.replace(
+    /(\x1b\]8;;)([^\x1b]+)(\x1b\\)/g,
+    (match, open, url, close) => {
+      try {
+        const parsed = new URL(url);
+        if (!parsed.pathname.startsWith('/c/')) return match;
+        parsed.searchParams.set('cc_uid', userId);
+        return `${open}${parsed}${close}`;
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
 // The post id is embedded in each line's /c/ link; used for the no-repeat
 // history and impression analytics.
 const linePostId = (line) => line.match(/\/c\/([^?\s]+)/)?.[1] ?? null;
@@ -107,7 +137,7 @@ async function refreshCache() {
     const postId = linePostId(line);
     if (seen.has(postId ?? line)) return [];
     seen.add(postId ?? line);
-    return [{ line, postId }];
+    return [{ line: tagClickUrls(line), postId }];
   });
   let items = all
     .filter((i) => !i.postId || !history[i.postId])


### PR DESCRIPTION
## Why

The statusline plugin's anonymous identity (minted via `/boot`, carried on impressions) and the browser's cookie identity (carried on `/c/` clicks) are different anonymous users — we don't support login in the plugin — so impressions and clicks can't be matched in analytics.

## What

At refresh time the plugin rewrites each server-rendered line's OSC 8 `/c/` link, appending its own id as **`cc_uid`** (`userid` is reserved for referral traffic).

- **No API change needed**: the `/c/` redirect already logs the complete query string into the click event's `query_params`, and forwards only `utm_*` to the post page — so the id is captured server-side but never leaks into webapp URLs or referral tracking.
- Join key in ClickHouse: impressions `user_id` = clicks `JSONExtractString(query_params, 'cc_uid')`.
- Respects the opt-out: with `DAILY_DEV_TELEMETRY=0` no id is attached (verified: 0 of 20 lines tagged).
- Robust to server format changes: the URL is parsed from the OSC 8 escape and re-serialized, not string-patched.

## Verified against prod

- All 20 fetched lines tagged with the local identity id.
- Tagged URL 302s correctly; `location` carries only `utm_*` (no `cc_uid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)