### PR TITLE
docs: remove obsolete public local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 We know how hard it is to be a developer. It doesn't have to be. <br/>
 daily.dev is the homepage every developer deserves. <br/>
-A personalized developer news feed, dev communities, and search. Free. Much better than what's out there. Maybe ;)
+A personalized developer news feed, dev communities, and search. Free, and open source. Much better than what's out there. Maybe ;)
 
 [Product Docs][product-docs-link] · [Changelog][changelog-link] · [Report a Bug][report-bug-link] · [Request a Feature][github-discussions-link] · [Swag Store][swag-store-link] · [Brand Assets][brand-book-link]
 
@@ -42,7 +42,7 @@ A personalized developer news feed, dev communities, and search. Free. Much bett
 > [!IMPORTANT]
 > Star us to show your support and love for daily.dev ⭐️
 
-daily.dev is a free personalized news feed for developers, used by millions of developers worldwide. It aggregates articles, tutorials, release notes, and news from 2,000+ trusted sources across the web, and personalizes your feed based on the tags you follow (like #webdev, #ai, #devops) and what you read.
+daily.dev is a free, open source personalized news feed for developers, used by millions of developers worldwide. It aggregates articles, tutorials, release notes, and news from 2,000+ trusted sources across the web, and personalizes your feed based on the tags you follow (like #webdev, #ai, #devops) and what you read.
 
 You can use daily.dev as a new tab browser extension for Chrome and Edge, as a web app, or with the daily.dev mobile apps for iOS and Android. Beyond the feed, daily.dev is a community: join Squads to share and discuss content with other developers, comment on posts, bookmark what you want to read later, and search across everything.
 
@@ -107,15 +107,15 @@ Yes. The core daily.dev experience (the personalized feed, extension, mobile app
 </details>
 
 <details>
-<summary><strong>Are daily.dev's web and extension apps open source?</strong></summary>
+<summary><strong>Is daily.dev open source?</strong></summary>
 <br>
-Yes. The web app and browser extension are open source under the AGPL-3.0 license. Their source lives in <a href="https://github.com/dailydotdev/apps">dailydotdev/apps</a>.
+Yes. daily.dev is open source under the AGPL-3.0 license. This repository is the central hub, and the frontend applications (extension and web app) live in <a href="https://github.com/dailydotdev/apps">dailydotdev/apps</a>.
 </details>
 
 <details>
 <summary><strong>What are we doing to ensure daily.dev is safe?</strong></summary>
 <br>
-The browser extension only replaces your new tab page. It never tracks your browsing on other websites, never reads or modifies content on other pages, never accesses your browsing history, and never injects scripts into any website. It requests only the permissions it needs, and its public source code lets you verify all of this yourself. Your data is never sold.
+The browser extension only replaces your new tab page. It never tracks your browsing on other websites, never reads or modifies content on other pages, never accesses your browsing history, and never injects scripts into any website. It requests only the permissions it needs, and because daily.dev is fully open source, you can verify all of this in the code yourself. Your data is never sold.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 We know how hard it is to be a developer. It doesn't have to be. <br/>
 daily.dev is the homepage every developer deserves. <br/>
-A personalized developer news feed, dev communities, and search. Free, and open source. Much better than what's out there. Maybe ;)
+A personalized developer news feed, dev communities, and search. Free. Much better than what's out there. Maybe ;)
 
 [Product Docs][product-docs-link] · [Changelog][changelog-link] · [Report a Bug][report-bug-link] · [Request a Feature][github-discussions-link] · [Swag Store][swag-store-link] · [Brand Assets][brand-book-link]
 
@@ -31,8 +31,6 @@ A personalized developer news feed, dev communities, and search. Free, and open 
 [![][share-mastodon-shield]][share-mastodon-link]
 [![][share-linkedin-shield]][share-linkedin-link]
 
-<sup>Want to contribute? [Run our app locally](https://github.com/dailydotdev/daily?tab=readme-ov-file#-running-dailydev-locally)</sup>
-
 <img src="assets/github repo banner with browser.png" alt="daily.dev personalized developer news feed shown in a browser new tab" width="100%">
 </br>
 <a href="https://youtu.be/igZCEr3HwCg"><strong>👀 Watch daily.dev in action → </strong></a>
@@ -44,7 +42,7 @@ A personalized developer news feed, dev communities, and search. Free, and open 
 > [!IMPORTANT]
 > Star us to show your support and love for daily.dev ⭐️
 
-daily.dev is a free, open source personalized news feed for developers, used by millions of developers worldwide. It aggregates articles, tutorials, release notes, and news from 2,000+ trusted sources across the web, and personalizes your feed based on the tags you follow (like #webdev, #ai, #devops) and what you read.
+daily.dev is a free personalized news feed for developers, used by millions of developers worldwide. It aggregates articles, tutorials, release notes, and news from 2,000+ trusted sources across the web, and personalizes your feed based on the tags you follow (like #webdev, #ai, #devops) and what you read.
 
 You can use daily.dev as a new tab browser extension for Chrome and Edge, as a web app, or with the daily.dev mobile apps for iOS and Android. Beyond the feed, daily.dev is a community: join Squads to share and discuss content with other developers, comment on posts, bookmark what you want to read later, and search across everything.
 
@@ -109,15 +107,15 @@ Yes. The core daily.dev experience (the personalized feed, extension, mobile app
 </details>
 
 <details>
-<summary><strong>Is daily.dev open source?</strong></summary>
+<summary><strong>Are daily.dev's web and extension apps open source?</strong></summary>
 <br>
-Yes. daily.dev is open source under the AGPL-3.0 license. This repository is the central hub, and the frontend applications (extension and web app) live in <a href="https://github.com/dailydotdev/apps">dailydotdev/apps</a>.
+Yes. The web app and browser extension are open source under the AGPL-3.0 license. Their source lives in <a href="https://github.com/dailydotdev/apps">dailydotdev/apps</a>.
 </details>
 
 <details>
 <summary><strong>What are we doing to ensure daily.dev is safe?</strong></summary>
 <br>
-The browser extension only replaces your new tab page. It never tracks your browsing on other websites, never reads or modifies content on other pages, never accesses your browsing history, and never injects scripts into any website. It requests only the permissions it needs, and because daily.dev is fully open source, you can verify all of this in the code yourself. Your data is never sold.
+The browser extension only replaces your new tab page. It never tracks your browsing on other websites, never reads or modifies content on other pages, never accesses your browsing history, and never injects scripts into any website. It requests only the permissions it needs, and its public source code lets you verify all of this yourself. Your data is never sold.
 </details>
 
 <details>
@@ -175,21 +173,6 @@ daily.dev might look simple on the surface, but actually, it is powered by a com
 
 * [action-devcard](https://github.com/dailydotdev/action-devcard) - GitHub Actions for adding daily DevCard to GitHub profile. Read [the guide](https://daily.dev/blog/adding-the-daily-devcard-to-your-github-profile) to set it up.
 
-
-## 🚀 Running daily.dev locally
-
-> [!NOTE]
-> Currently, not all services are ready (or needed) for local environments, so Daily Redirector, Daily Monetization, and Authentication services are not available for you.
-
-
-To spin up a local environment, you will need Docker. Do the steps below and you should be able to start trying to center a div:
-- Fork the apps repo: https://github.com/dailydotdev/apps
-- Pull it locally
-- Run `docker compose up`
-- Apply all migrations by running `docker compose exec daily-api node ./node_modules/typeorm/cli.js migration:run -d src/data-source.js`
-- Once done, seed your local data by running `docker compose exec daily-api node ./bin/import`
-- Then lastly, run `npm run dev:oss`
-- The app should run at `http://localhost:5002/`
 
 ## 🙌 Want to contribute?
 


### PR DESCRIPTION
## Summary
- remove public local-run instructions and CTA
- scope source-availability wording to the web and extension apps
- update extension safety copy to refer to publicly available source

## Validation
- git diff --check